### PR TITLE
Store item keys

### DIFF
--- a/item.go
+++ b/item.go
@@ -13,6 +13,9 @@ type Item struct {
 	// ItemID is the unique ID of the Item.
 	ItemID string `json:"itemid"`
 
+	// ItemKey is the key name of the item.
+	ItemKey string `json:"key_"`
+
 	// Itemname is the technical name of the Item.
 	ItemName string `json:"name"`
 


### PR DESCRIPTION
Allow access to item key names, which is useful for processing items without fragile parsing of the human item name.